### PR TITLE
Add link to docker documentation

### DIFF
--- a/_data/docs-nav.yaml
+++ b/_data/docs-nav.yaml
@@ -10,8 +10,11 @@
       href: "/docs/install/prerequisites/"
     - title: "WAR"
       href: "/docs/install/war/"
+    - title: "Docker"
+      href: "/docs/install/docker/"
     - title: "Stand-alone"
       href: "/docs/install/war-standalone/"
+
 #
 # Build targets not suported yet
 #


### PR DESCRIPTION
This enables a link to the docker documentation.

See [pull request](https://github.com/airsonic/documentation/pull/21) in documentation repo