### PR TITLE
Correct link to documentation contributing guide

### DIFF
--- a/pages/contribute.md
+++ b/pages/contribute.md
@@ -17,7 +17,7 @@ If not get the information needed for a bug report and write us a new issue to o
 
 The documentation is actually not really well documented, so any contributions is welcomed.
 
-See our documentation [contributing guide](https://github.com/airsonic/documentation/blob/stable/contribue.md).
+See our documentation [contributing guide](https://github.com/airsonic/documentation/blob/master/CONTRIBUTING.md).
 
 ##### Submit a patch ?!
 


### PR DESCRIPTION
The current one 404s.