### PR TITLE
Change installation manual to avoid package version conflicts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 Gemfile
 
 # Jekyll
+.jekyll-metadata
 _site
 Gemfile.lock

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ This is the [Airsonic website](https://airsonic.github.io/) repo.
 - Clone the website repo `git clone https://github.com/airsonic/airsonic.github.io`.
 - Change directory into the cloned repo `cd airsonic.github.io`.
 - Clone the documentation submodule `git clone https://github.com/airsonic/documentation pages/docs`.
-- Install [Jekyll](https://jekyllrb.com/).
-- Run jekyll serve --watch.
+- Install `ruby` and [`bundler`](https://bundler.io/) (`gem install bundler`).
+- Install local dependencies: `bundler install`
+- Run `bundler exec jekyll serve --watch`.
 
 ### Media sources
 


### PR DESCRIPTION
This is only for the installation of the packages required to build the docs, thus it should concern only few people. I found that with the current docs I was getting errors because of mismatching dependencies, so I updated the docs to use the once described in the `Gemfile`.

Is there a reason for `Gemfile` and `Gemfile.lock` being `.gitignore`d? I'm not so familiar with ruby, but it does make builds across different computers way less predictable, no? Maybe I'm just scarred from JS dependency management. ;)