### PR TITLE
 Fixed links, updated contributing link, and removed Homebrew JDK install instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 _site/
 .sass-cache/
 .jekyll-metadata
+.vscode

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ This is the [Airsonic website](https://airsonic.github.io/) repo.
 - Install local dependencies: `bundler install`
 - Run `bundler exec jekyll serve --watch`.
 
+## Contributing
+
+Please see [this guide](https://github.com/airsonic/documentation/blob/master/.github/CONTRIBUTING.md) for any contribution.
+
+Use _update_submodule.sh_ to update the submodule [page/docs](https://github.com/airsonic/documentation).
+
 ### Media sources
 
 - [Main page background picture](https://airsonic.github.io/img/album-wall.jpg) is distributed under Creative Commons 2.0 license. All right reserved to __Heath Alseike__ for his pictures available on [flickr](https://www.flickr.com/photos/99624358@N00/5506222889/).__Really nice album wall picture by the way !__

--- a/pages/contribute.md
+++ b/pages/contribute.md
@@ -17,7 +17,7 @@ If not get the information needed for a bug report and write us a new issue to o
 
 The documentation is actually not really well documented, so any contributions is welcomed.
 
-See our documentation [contributing guide](https://github.com/airsonic/documentation/blob/master/CONTRIBUTING.md).
+See our documentation [contributing guide](https://github.com/airsonic/documentation/blob/master/.github/CONTRIBUTING.md).
 
 ##### Submit a patch?!
 


### PR DESCRIPTION
The contributing link was pointing to the wrong area. I was updated sometime in the past to _.github/CONTRIBUTING.md_ instead of the on the root.

The Homebrew cask install of JDK is OpenJDK 11. Airsonic does not work with JDK 11. So I updated the instructions to use Oracle JDK 8, which is on the Prerequisites page.