### PR TITLE
Improve docs structure

### DIFF
--- a/_data/docs-nav.yaml
+++ b/_data/docs-nav.yaml
@@ -4,6 +4,9 @@
 - title: "Getting started"
   href: "/docs/"
 
+- title: "Migrate from Subsonic"
+  href: "/docs/migrate/"
+
 - title: "Install"
   subcategories:
     - title: "Prerequisites"
@@ -52,37 +55,36 @@
       href: "/docs/proxy/nginx/"
     - title: "HAproxy"
       href: "/docs/proxy/haproxy/"
-
-- title: "Migrate"
-  href: "/docs/migrate/"
+    - title: "Caddy"
+      href: "/docs/proxy/caddy/"
 
 - title: "Database"
   href: "/docs/database/"
 
-- title: "Transcode"
-  href: "/docs/transcode/"
-
-- title: "Jukebox"
-  href: "/docs/jukebox/"
-
-- title: "Metadata"
+- title: "Media"
   subcategories:
-    - title: "FFprobe"
+    - title: "Transcode"
+      href: "/docs/transcode/"
+    - title: "Jukebox"
+      href: "/docs/jukebox/"
+    - title: "Ffprobe"
       href: "/docs/metadata/ffprobe/"
-
-- title: "LDAP"
-  href: "/docs/ldap/"
 
 - title: "Apps"
   href: "/docs/apps/"
 
-- title: "Logging"
-  href: "/docs/logging/"
-
-- title: "API"
-  href: "/docs/api/"
+- title: "Advanced"
+  subcategories:
+    - title: "LDAP"
+      href: "/docs/ldap/"
+    - title: "Logging"
+      href: "/docs/logging/"
+    - title: "API"
+      href: "/docs/api/"
+    - title: "Captcha"
+      href: "/docs/captcha/"
 
 - title: "Developer"
   subcategories:
-    - title: "Setup Intellij"
+    - title: "Setup IntelliJ"
       href: "/docs/developer/intellij/"

--- a/_data/docs-nav.yaml
+++ b/_data/docs-nav.yaml
@@ -88,3 +88,7 @@
   subcategories:
     - title: "Setup IntelliJ"
       href: "/docs/developer/intellij/"
+    - title: "Using Maven"
+      href: "/docs/developer/maven/"
+    - title: "Performance tests"
+      href: "/docs/developer/performance/"


### PR DESCRIPTION
I tried to reorganize a bit the ToC for the documentation, so that some common topics are grouped together. Let me know if you have suggestions for how to do this better!

I also added https://github.com/airsonic/airsonic-docs/pull/89 (but will update the submodule link when it's merged).