### PR TITLE
Update Install instructions in readme and nav.yaml for new windows docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,12 @@ This is the [Airsonic website](https://airsonic.github.io/) repo.
 - Clone the website repo `git clone https://github.com/airsonic/airsonic.github.io`.
 - Change directory into the cloned repo `cd airsonic.github.io`.
 - Clone the documentation submodule `git clone https://github.com/airsonic/airsonic-docs docs`.
-- Install `ruby` and [`bundler`](https://bundler.io/) (`gem install bundler`).
-- Install local dependencies: `bundler install`
+- For the next steps, go one directory up `cd ..`
+- Install `ruby` with the devkit. If you run it on Windows, don't install it to `C:\Program Files` as you will get trouble with the space later!
+- Install [`bundler`](https://bundler.io/) (`gem install bundler`).
+- Install [`jekyll`](https://jekyllrb.com/) (`gem install jekyll`).
+- Update local dependencies: `bundler update`.
+- Install local dependencies: `bundler install`.
 - Run `bundler exec jekyll serve --watch`.
 
 The above wrapped into a little script (it assume you have bundler installed):

--- a/_data/docs-nav.yaml
+++ b/_data/docs-nav.yaml
@@ -21,6 +21,8 @@
       href: "/docs/install/homebrew/"
     - title: "Docker"
       href: "/docs/install/docker/"
+    - title: "Windows"
+      href: "/docs/install/windows/"
     - title: "Example"
       subcategories:
         - title: "FreeBSD/NAS"
@@ -57,6 +59,8 @@
       href: "/docs/proxy/haproxy/"
     - title: "Caddy"
       href: "/docs/proxy/caddy/"
+    - title: "IIS"
+      href: "/docs/proxy/iis/"
 
 - title: "Database"
   href: "/docs/database/"


### PR DESCRIPTION
This pull requests comes hand in hand with [this pull request](https://github.com/airsonic/airsonic-docs/pull/92/commits) about new installation instructions for Windows and IIS.

During setup Jekyll I had some issues by following the provided instructions, therefore I also updated the readme of this repo as well...